### PR TITLE
revision cleanup + prevention of new ones 

### DIFF
--- a/docroot/modules/custom/discourse_comments/src/Plugin/Block/DiscourseCommentBlock.php
+++ b/docroot/modules/custom/discourse_comments/src/Plugin/Block/DiscourseCommentBlock.php
@@ -73,7 +73,7 @@ class DiscourseCommentBlock extends BlockBase implements ContainerFactoryPluginI
         // Save topic count.
         $post_count = ($topic['posts_count'] > 0) ? ($topic['posts_count'] - 1) : 0;
         $field_discourse[0]['comment_count'] = $post_count;
-        $node->set('discourse_field', $field_discourse)->save();
+        //$node->set('discourse_field', $field_discourse)->save();
         $comments = [];
         $default_avatar_image = $this->discourseApiClient->getDefaultAvatar();
         if (isset($topic['post_stream']) && isset($topic['post_stream']['posts'])) {

--- a/docroot/modules/custom/mauticorg_core/mauticorg_core.install
+++ b/docroot/modules/custom/mauticorg_core/mauticorg_core.install
@@ -5,9 +5,84 @@
  * Contains update hooks for Mauticorg site.
  */
 
+use Drupal\Core\Entity\EntityStorageException;
+
 /**
  * Migrate config for mauticorg_core.site_settings.
  */
 function mauticorg_core_update_8001() {
   _mauticorg_core_import_config('mauticorg_core.site_settings');
+}
+
+/**
+ * Remove obsolete revisions and set correct changed dates.
+ */
+function mauticorg_core_update_8002() {
+
+  // Ensure we can handle massive group contacts
+  \Drupal::database()->query("SET @@group_concat_max_len = 10000000000;")->execute();
+
+  \Drupal::logger('mauticorg_core')->notice("starting cleanup");
+
+  $query = "
+    select
+        r.nid,
+        r.revision_timestamp,
+        group_concat(r.vid) as 'vids',
+        max(r.vid) as 'max_vid',
+        n.vid as 'node_vid',
+        count(*) as 'no_of_revs'
+    from node_revision r
+    join node n on r.nid = n.nid
+    group by nid, revision_timestamp
+    having count(*) > 1
+    order by count(*) desc;
+    ";
+
+  $revisionInfo = \Drupal::database()->query($query)->fetchAll();
+  $storageManager = \Drupal::entityTypeManager()->getStorage('node');
+
+  foreach ($revisionInfo as $row) {
+
+    \Drupal::logger('mauticorg_core')->notice("processing nid {$row->nid} (timestamp: {$row->revision_timestamp}): {$row->no_of_revs} items to check");
+    $revIds = explode(',', $row->vids);
+    foreach ($revIds as $id) {
+      // only delete the revision if it's not the max revision of the group, or it is the default revision of the node.
+      if ($id && $id != $row->max_vid && $id != $row->node_vid) {
+        try {
+          $storageManager->deleteRevision($id);
+        } catch (EntityStorageException $e) {
+          // Nothing to do here
+        }
+      }
+    }
+  }
+
+  // ensure all revisions are shown in the revision overview
+  \Drupal::database()->query("
+    update node_field_revision set revision_translation_affected = 1 where revision_translation_affected is NULL;
+   ")->execute();
+
+  // Update the timestamps of the revisions, so correct change dates can be shown,
+  // both for changed date on the node and date of the revision.
+  \Drupal::database()->query("
+    update node_field_revision fr
+    join node_revision r on fr.vid = r.vid
+    set fr.changed = r.revision_timestamp
+    where r.revision_timestamp < fr.changed;
+  ")->execute();
+
+  \Drupal::database()->query("
+    update node_field_revision fr
+    join node_revision r on fr.vid = r.vid
+    set r.revision_timestamp = fr.changed
+    where r.revision_timestamp > fr.changed;
+  ")->execute();
+
+  \Drupal::database()->query("
+    update node_field_data dr
+    join node_field_revision fr on fr.vid = dr.vid
+    set dr.changed = fr.changed
+    where dr.changed > fr.changed;
+  ")->execute();
 }

--- a/docroot/modules/custom/mauticorg_core/mauticorg_core.install
+++ b/docroot/modules/custom/mauticorg_core/mauticorg_core.install
@@ -5,84 +5,9 @@
  * Contains update hooks for Mauticorg site.
  */
 
-use Drupal\Core\Entity\EntityStorageException;
-
 /**
  * Migrate config for mauticorg_core.site_settings.
  */
 function mauticorg_core_update_8001() {
   _mauticorg_core_import_config('mauticorg_core.site_settings');
-}
-
-/**
- * Remove obsolete revisions and set correct changed dates.
- */
-function mauticorg_core_update_8002() {
-
-  // Ensure we can handle massive group contacts
-  \Drupal::database()->query("SET @@group_concat_max_len = 10000000000;")->execute();
-
-  \Drupal::logger('mauticorg_core')->notice("starting cleanup");
-
-  $query = "
-    select
-        r.nid,
-        r.revision_timestamp,
-        group_concat(r.vid) as 'vids',
-        max(r.vid) as 'max_vid',
-        n.vid as 'node_vid',
-        count(*) as 'no_of_revs'
-    from node_revision r
-    join node n on r.nid = n.nid
-    group by nid, revision_timestamp
-    having count(*) > 1
-    order by count(*) desc;
-    ";
-
-  $revisionInfo = \Drupal::database()->query($query)->fetchAll();
-  $storageManager = \Drupal::entityTypeManager()->getStorage('node');
-
-  foreach ($revisionInfo as $row) {
-
-    \Drupal::logger('mauticorg_core')->notice("processing nid {$row->nid} (timestamp: {$row->revision_timestamp}): {$row->no_of_revs} items to check");
-    $revIds = explode(',', $row->vids);
-    foreach ($revIds as $id) {
-      // only delete the revision if it's not the max revision of the group, or it is the default revision of the node.
-      if ($id && $id != $row->max_vid && $id != $row->node_vid) {
-        try {
-          $storageManager->deleteRevision($id);
-        } catch (EntityStorageException $e) {
-          // Nothing to do here
-        }
-      }
-    }
-  }
-
-  // ensure all revisions are shown in the revision overview
-  \Drupal::database()->query("
-    update node_field_revision set revision_translation_affected = 1 where revision_translation_affected is NULL;
-   ")->execute();
-
-  // Update the timestamps of the revisions, so correct change dates can be shown,
-  // both for changed date on the node and date of the revision.
-  \Drupal::database()->query("
-    update node_field_revision fr
-    join node_revision r on fr.vid = r.vid
-    set fr.changed = r.revision_timestamp
-    where r.revision_timestamp < fr.changed;
-  ")->execute();
-
-  \Drupal::database()->query("
-    update node_field_revision fr
-    join node_revision r on fr.vid = r.vid
-    set r.revision_timestamp = fr.changed
-    where r.revision_timestamp > fr.changed;
-  ")->execute();
-
-  \Drupal::database()->query("
-    update node_field_data dr
-    join node_field_revision fr on fr.vid = dr.vid
-    set dr.changed = fr.changed
-    where dr.changed > fr.changed;
-  ")->execute();
 }


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->

this PR addresses the huge amounts of obsolete revisions of blog items by
* cleaning them up in an update hook
* setting the change dates correct, so they are relevant change date of the revision
* preventing a new revision is created every time a blog item is rendered (which is on production worst case every 15 minutes).

As this PR is a blocker for a smoother dev experience (no need to downsync and import a db of 6GB), we (Dropsolid) will merge and deploy this change via the Dropsolid Platform.

Afterwards, following PR's can follow the normal flow with the different QA envs.

## How to test

The update hook has run on the dev env (https://mauticorg.dev.sites.dropsolid-sites.com/), with a database dump of 29/08

* login to the dev (blocked by #20)
* verify the list fo blog items is correct
* verify the list of revisions of blog items is correct
* verify you can still add blog items (TO DOUBLE CHECK, AS THIS WILL POTENTIALLY SYNC TO DISCOURSE)

### content overview list

relevant changed dates

* **before**
![Screenshot 2023-08-30 at 15 02 42](https://github.com/mautic/mautic.org-website/assets/3983285/04b4b87f-7887-4f92-ad86-ef7289746829)

* **after**
![Screenshot 2023-08-30 at 15 02 55](https://github.com/mautic/mautic.org-website/assets/3983285/4377460b-b15a-4d66-a64a-ce0336bd5aa6)


Next to that, this also solves a performance issue (manually mitigated on production).
On every revision save, the cachetags for the node are invalidated.
In case of the blog content type, this is `node_list` and `node_list:blog`.
As a list of blog items is shown on every page, this literally means that the whole site is only cacheable for a few seconds.


### revision list

relevant revisions

* **before**
![Screenshot 2023-08-30 at 15 06 46](https://github.com/mautic/mautic.org-website/assets/3983285/6242714b-87cf-407b-a3e0-c46c27580214)

* **after**
![Screenshot 2023-08-30 at 15 06 58](https://github.com/mautic/mautic.org-website/assets/3983285/048cb7b4-9987-4731-b162-0f59906a70bc)


## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | **yes**/no
| Did you apply meaningful labels to the pull request? | yes/no
| Did you perform a self review first? | **yes**/no
| Documentation reflects changes? | yes/**no**
| `CHANGELOG` reflects changes? | yes/**no**
| Unit/Functional tests reflect changes? | yes/**no**
| Did you perform browser testing? | yes/**no**
| Risk level | Low, **Medium**, High
| Relevant links | #19
