### PR TITLE
Create funding-manifest-urls

### DIFF
--- a/docroot/.well-known/funding-manifest-urls
+++ b/docroot/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://github.com/mautic/mautic/blob/5.x/funding.json


### PR DESCRIPTION

## Summary
In applying for the funding from the FLOSS fund, creating the funding.json file requires us to link to https://github.com/mautic/mautic/blob/5.x/funding.json in a funding manifest file on the .well-known directory of any sites we're linking out to.

This PR should add that directory and file, per the instructions here: https://floss.fund/funding-manifest/
## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | N/A
| `CHANGELOG` reflects changes? | N/A
| Unit/Functional tests reflect changes? | N/A
| Did you perform browser testing? | N/A
| Risk level | Low
| Relevant links | N/A
